### PR TITLE
Make Nimble/Math.hpp independent of Qt

### DIFF
--- a/Nimble/Math.hpp
+++ b/Nimble/Math.hpp
@@ -21,8 +21,6 @@
 # include <float.h>
 #endif
 
-#include <QtGlobal>
-
 #include <cstdint>
 #include <limits>
 #include <cstdlib>


### PR DESCRIPTION
Make possible to use Nimble matrixes and vectors in a pure C++ without dependency on Qt.