### PR TITLE
Added missing license headers

### DIFF
--- a/EmailSending/Email.cpp
+++ b/EmailSending/Email.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "Email.hpp"
 
 #include <cassert>

--- a/EmailSending/Email.hpp
+++ b/EmailSending/Email.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RADIANT_EMAIL_HPP
 #define RADIANT_EMAIL_HPP
 

--- a/EmailSending/Export.hpp
+++ b/EmailSending/Export.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef EMAIL_EXPORT_HPP
 #define EMAIL_EXPORT_HPP
 

--- a/EmailSending/SendImplementation.cpp
+++ b/EmailSending/SendImplementation.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "SendImplementation.hpp"
 
 #include <QMimeDatabase>

--- a/EmailSending/SendImplementation.hpp
+++ b/EmailSending/SendImplementation.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef SENDIMPLEMENTATION_HPP
 #define SENDIMPLEMENTATION_HPP
 

--- a/EmailSending/Sender.cpp
+++ b/EmailSending/Sender.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "Sender.hpp"
 
 #include "SendImplementation.hpp"

--- a/EmailSending/Sender.hpp
+++ b/EmailSending/Sender.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RADIANT_EMAILSENDER_HPP
 #define RADIANT_EMAILSENDER_HPP
 

--- a/Examples/GLBench/Main.cpp
+++ b/Examples/GLBench/Main.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 
 #include <Luminous/Luminous.hpp>
 

--- a/Examples/GeometryShaderQuads/GeometryShaderQuads.cpp
+++ b/Examples/GeometryShaderQuads/GeometryShaderQuads.cpp
@@ -1,3 +1,12 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
 
 #include <Luminous/Luminous.hpp>
 

--- a/Examples/ImageExample/Main.cpp
+++ b/Examples/ImageExample/Main.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 
 #include <Luminous/Luminous.hpp>
 

--- a/Examples/PlatformExample/Main.cpp
+++ b/Examples/PlatformExample/Main.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 
 #include <Radiant/PlatformUtils.hpp>
 #include <Radiant/Trace.hpp>

--- a/Examples/SDLVideoPlayer/Main.cpp
+++ b/Examples/SDLVideoPlayer/Main.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 
 #include <Luminous/Luminous.hpp>
 

--- a/Examples/ShaderExample/Main.cpp
+++ b/Examples/ShaderExample/Main.cpp
@@ -1,4 +1,12 @@
-
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
 
 #include <Luminous/Luminous.hpp>
 #include <Luminous/Shader.hpp>

--- a/Examples/TimeCalculations/TimeCalculations.cpp
+++ b/Examples/TimeCalculations/TimeCalculations.cpp
@@ -1,3 +1,12 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
 
 #include <Radiant/DateTime.hpp>
 #include <Radiant/Trace.hpp>

--- a/Examples/ValidatingXML/Main.cpp
+++ b/Examples/ValidatingXML/Main.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include <Valuable/Valuable.hpp>
 #include <Valuable/DOMDocument.hpp>
 

--- a/Examples/ValueTest/Main.cpp
+++ b/Examples/ValueTest/Main.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include <Valuable/Node.hpp>
 #include <Valuable/Valuable.hpp>
 #include <Valuable/AttributeFloat.hpp>

--- a/Examples/VertexBuffers/Main.cpp
+++ b/Examples/VertexBuffers/Main.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include <SDL/SDL.h>
 #include <Luminous/Luminous.hpp>
 #include <Luminous/VertexBuffer.hpp>

--- a/Luminous/BezierSpline.cpp
+++ b/Luminous/BezierSpline.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "BezierSpline.hpp"
 
 namespace Luminous

--- a/Luminous/BezierSpline.hpp
+++ b/Luminous/BezierSpline.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "CubicBezierCurve.hpp"

--- a/Luminous/BezierSplineBuilder.cpp
+++ b/Luminous/BezierSplineBuilder.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "BezierSplineBuilder.hpp"
 #include "BezierSplineFitter.hpp"
 

--- a/Luminous/BezierSplineBuilder.hpp
+++ b/Luminous/BezierSplineBuilder.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "BezierSpline.hpp"

--- a/Luminous/BezierSplineEraser.hpp
+++ b/Luminous/BezierSplineEraser.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "BezierSpline.hpp"

--- a/Luminous/BezierSplineFitter.cpp
+++ b/Luminous/BezierSplineFitter.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "BezierSplineFitter.hpp"
 #include "CubicBezierCurve.hpp"
 

--- a/Luminous/BezierSplineFitter.hpp
+++ b/Luminous/BezierSplineFitter.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "Export.hpp"

--- a/Luminous/BezierSplineRenderer.cpp
+++ b/Luminous/BezierSplineRenderer.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "BezierSplineRenderer.hpp"
 #include "BezierSplineTessellator.hpp"
 #include "Buffer.hpp"

--- a/Luminous/BezierSplineRenderer.hpp
+++ b/Luminous/BezierSplineRenderer.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "Export.hpp"

--- a/Luminous/BezierSplineTessellator.cpp
+++ b/Luminous/BezierSplineTessellator.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "BezierSplineTessellator.hpp"
 #include "CubicBezierCurve.hpp"
 

--- a/Luminous/BezierSplineTessellator.hpp
+++ b/Luminous/BezierSplineTessellator.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "BezierSplineFitter.hpp"

--- a/Luminous/ColorCorrection.cpp
+++ b/Luminous/ColorCorrection.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "ColorCorrection.hpp"
 
 #include <algorithm>

--- a/Luminous/CubicBezierCurve.hpp
+++ b/Luminous/CubicBezierCurve.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include <Nimble/Circle.hpp>

--- a/Luminous/DisplayConfigWin.cpp
+++ b/Luminous/DisplayConfigWin.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "DisplayConfigWin.hpp"
 
 #include <QRegularExpression>

--- a/Luminous/DisplayConfigWin.hpp
+++ b/Luminous/DisplayConfigWin.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef LUMINOUS_DISPLAY_CONFIG_WIN_HPP
 #define LUMINOUS_DISPLAY_CONFIG_WIN_HPP
 

--- a/Luminous/DxInterop.cpp
+++ b/Luminous/DxInterop.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "DxInterop.hpp"
 
 #include <Radiant/StringUtils.hpp>

--- a/Luminous/DxInterop.hpp
+++ b/Luminous/DxInterop.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef LUMINOUS_DXINTEROP_HPP
 #define LUMINOUS_DXINTEROP_HPP
 

--- a/Luminous/DxSharedTexture.cpp
+++ b/Luminous/DxSharedTexture.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "ContextArray.hpp"
 #include "DxInterop.hpp"
 #include "DxSharedTexture.hpp"

--- a/Luminous/DxSharedTexture.hpp
+++ b/Luminous/DxSharedTexture.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "Image.hpp"

--- a/Luminous/GPUAffinity.cpp
+++ b/Luminous/GPUAffinity.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "DisplayConfigWin.hpp"
 #include "GPUAffinity.hpp"
 

--- a/Luminous/GPUAffinity.hpp
+++ b/Luminous/GPUAffinity.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef LUMINOUS_GPU_AFFINITY_HPP
 #define LUMINOUS_GPU_AFFINITY_HPP
 

--- a/Luminous/GPUAssociation.cpp
+++ b/Luminous/GPUAssociation.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "GPUAssociation.hpp"
 
 #include <Radiant/Platform.hpp>

--- a/Luminous/GPUAssociation.hpp
+++ b/Luminous/GPUAssociation.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef GPUASSOCIATION_HPP
 #define GPUASSOCIATION_HPP
 

--- a/Luminous/GfxDriver.hpp
+++ b/Luminous/GfxDriver.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 namespace Luminous

--- a/Luminous/MaskGuard.cpp
+++ b/Luminous/MaskGuard.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "MaskGuard.hpp"
 
 namespace Luminous

--- a/Luminous/MaskGuard.hpp
+++ b/Luminous/MaskGuard.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef MASKGUARD_HPP
 #define MASKGUARD_HPP
 

--- a/Luminous/MemoryManager.cpp
+++ b/Luminous/MemoryManager.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "MemoryManager.hpp"
 
 #include <Radiant/PlatformUtils.hpp>

--- a/Luminous/MemoryManager.hpp
+++ b/Luminous/MemoryManager.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef LUMINOUS_MEMORYMANAGER_HPP
 #define LUMINOUS_MEMORYMANAGER_HPP
 

--- a/Luminous/MipmapRenderer.cpp
+++ b/Luminous/MipmapRenderer.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "MipmapRenderer.hpp"
 #include "RenderContext.hpp"
 

--- a/Luminous/MipmapRenderer.hpp
+++ b/Luminous/MipmapRenderer.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef LUMINOUS_MIPMAPRENDERER_HPP
 #define LUMINOUS_MIPMAPRENDERER_HPP
 

--- a/Luminous/Nvml.cpp
+++ b/Luminous/Nvml.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "Nvml.hpp"
 
 #include <Radiant/Sleep.hpp>

--- a/Luminous/Nvml.hpp
+++ b/Luminous/Nvml.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "Export.hpp"

--- a/Luminous/ScreenDetectorQt.cpp
+++ b/Luminous/ScreenDetectorQt.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "ScreenDetectorQt.hpp"
 
 #include <QApplication>

--- a/Luminous/ScreenDetectorQt.hpp
+++ b/Luminous/ScreenDetectorQt.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef LUMINOUS_SCREENDETECTORQT_H
 #define LUMINOUS_SCREENDETECTORQT_H
 

--- a/Luminous/SplineManager.cpp
+++ b/Luminous/SplineManager.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "SplineManager.hpp"
 
 #include <Luminous/RenderContext.hpp>

--- a/Luminous/SplineManager.hpp
+++ b/Luminous/SplineManager.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "Export.hpp"

--- a/Luminous/StateGL.cpp
+++ b/Luminous/StateGL.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "StateGL.hpp"
 #include "RenderDriverGL.hpp"
 

--- a/Luminous/SwapGroups.cpp
+++ b/Luminous/SwapGroups.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "SwapGroups.hpp"
 
 #include <Radiant/Platform.hpp>

--- a/Luminous/SwapGroups.hpp
+++ b/Luminous/SwapGroups.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef LUMINOUS_SWAPGROUPS_HPP
 #define LUMINOUS_SWAPGROUPS_HPP
 

--- a/Luminous/UploadBuffer.cpp
+++ b/Luminous/UploadBuffer.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "BufferGL.hpp"
 #include "UploadBuffer.hpp"
 

--- a/Luminous/UploadBuffer.hpp
+++ b/Luminous/UploadBuffer.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "StateGL.hpp"

--- a/Nimble/Circle.cpp
+++ b/Nimble/Circle.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "Circle.hpp"
 
 namespace Nimble {

--- a/Nimble/Circle.hpp
+++ b/Nimble/Circle.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef NIMBLE_CIRCLE_HPP
 #define NIMBLE_CIRCLE_HPP
 

--- a/Nimble/ClipRegion.hpp
+++ b/Nimble/ClipRegion.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "Rect.hpp"

--- a/Pdf/Export.hpp
+++ b/Pdf/Export.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include <Radiant/Platform.hpp>

--- a/Pdf/PDFManager.cpp
+++ b/Pdf/PDFManager.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "PDFManager.hpp"
 
 #ifdef ENABLE_LUMINOUS

--- a/Pdf/PDFManager.hpp
+++ b/Pdf/PDFManager.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include <folly/futures/Future.h>

--- a/Punctual/Executors.cpp
+++ b/Punctual/Executors.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "Executors.hpp"
 
 namespace Punctual

--- a/Punctual/Executors.hpp
+++ b/Punctual/Executors.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "Export.hpp"

--- a/Punctual/Export.hpp
+++ b/Punctual/Export.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef PUNCTUAL_EXPORT_HPP
 #define PUNCTUAL_EXPORT_HPP
 

--- a/Punctual/Helpers.hpp
+++ b/Punctual/Helpers.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include <Radiant/Mutex.hpp>

--- a/Punctual/LimitedTimeExecutor.cpp
+++ b/Punctual/LimitedTimeExecutor.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "LimitedTimeExecutor.hpp"
 
 #include <Radiant/Timer.hpp>

--- a/Punctual/LimitedTimeExecutor.hpp
+++ b/Punctual/LimitedTimeExecutor.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "Export.hpp"

--- a/Punctual/TaskWrapper.hpp
+++ b/Punctual/TaskWrapper.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef TASKWRAPPER_HPP
 #define TASKWRAPPER_HPP
 

--- a/Radiant/ArrayMap.hpp
+++ b/Radiant/ArrayMap.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RADIANT_ARRAY_MAP_HPP
 #define RADIANT_ARRAY_MAP_HPP
 

--- a/Radiant/ArraySet.hpp
+++ b/Radiant/ArraySet.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RADIANT_ARRAY_SET_HPP
 #define RADIANT_ARRAY_SET_HPP
 

--- a/Radiant/BGThreadExecutor.cpp
+++ b/Radiant/BGThreadExecutor.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "BGThreadExecutor.hpp"
 #include <Radiant/Mutex.hpp>
 #include <QThread>

--- a/Radiant/BGThreadExecutor.hpp
+++ b/Radiant/BGThreadExecutor.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RADIANT_BGTHREADEXECUTOR_HPP
 #define RADIANT_BGTHREADEXECUTOR_HPP
 

--- a/Radiant/Blake3.hpp
+++ b/Radiant/Blake3.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include <blake3.h>

--- a/Radiant/BlockRingBuffer.hpp
+++ b/Radiant/BlockRingBuffer.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RADIANT_BLOCKRINGBUFFER_HPP
 #define RADIANT_BLOCKRINGBUFFER_HPP
 

--- a/Radiant/CacheManager.cpp
+++ b/Radiant/CacheManager.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "BGThread.hpp"
 #include "CacheManager.hpp"
 #include "LockFile.hpp"

--- a/Radiant/CacheManager.hpp
+++ b/Radiant/CacheManager.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "Flags.hpp"

--- a/Radiant/CommandLineArguments.cpp
+++ b/Radiant/CommandLineArguments.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "CommandLineArguments.hpp"
 
 namespace Radiant

--- a/Radiant/CommandLineArguments.hpp
+++ b/Radiant/CommandLineArguments.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RADIANT_COMMANDLINEARGUMENTS_HPP
 #define RADIANT_COMMANDLINEARGUMENTS_HPP
 

--- a/Radiant/CrashHandler.hpp
+++ b/Radiant/CrashHandler.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "Export.hpp"

--- a/Radiant/CrashHandlerBreakpad.cpp
+++ b/Radiant/CrashHandlerBreakpad.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "CrashHandler.hpp"
 #include "TraceCrashHandlerFilter.hpp"
 

--- a/Radiant/CrashHandlerCommon.cpp
+++ b/Radiant/CrashHandlerCommon.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "CrashHandler.hpp"
 #include "Trace.hpp"
 

--- a/Radiant/CrashHandlerCrashpad.cpp
+++ b/Radiant/CrashHandlerCrashpad.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "CrashHandler.hpp"
 #include "TraceCrashHandlerFilter.hpp"
 

--- a/Radiant/CrashHandlerDummy.cpp
+++ b/Radiant/CrashHandlerDummy.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "CrashHandler.hpp"
 
 namespace Radiant

--- a/Radiant/CycleRecord.cpp
+++ b/Radiant/CycleRecord.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "CycleRecord.hpp"
 #include "Trace.hpp"
 

--- a/Radiant/DeviceMonitor.cpp
+++ b/Radiant/DeviceMonitor.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "DeviceMonitor.hpp"
 
 #if defined(RADIANT_LINUX) && !defined(RADIANT_MOBILE)

--- a/Radiant/DeviceMonitor.hpp
+++ b/Radiant/DeviceMonitor.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef KTC_DEVICEMONITOR_HPP
 #define KTC_DEVICEMONITOR_HPP
 

--- a/Radiant/DeviceUtilsWin.cpp
+++ b/Radiant/DeviceUtilsWin.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "DeviceUtilsWin.hpp"
 #include "StringUtils.hpp"
 #include "Trace.hpp"

--- a/Radiant/DeviceUtilsWin.hpp
+++ b/Radiant/DeviceUtilsWin.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RADIANT_DEVICE_UTILS_WIN_HPP
 #define RADIANT_DEVICE_UTILS_WIN_HPP
 

--- a/Radiant/IniFile.cpp
+++ b/Radiant/IniFile.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "IniFile.hpp"
 #include "Trace.hpp"
 #include "QByteArrayHash.hpp"

--- a/Radiant/IniFile.hpp
+++ b/Radiant/IniFile.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "Export.hpp"

--- a/Radiant/ObjectPool.cpp
+++ b/Radiant/ObjectPool.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "ObjectPool.hpp"
 
 static std::vector<Radiant::ObjectPool*> s_pools;

--- a/Radiant/ObjectPool.hpp
+++ b/Radiant/ObjectPool.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RADIANT_OBJECTPOOL_HPP
 #define RADIANT_OBJECTPOOL_HPP
 

--- a/Radiant/OnDemandExecutor.cpp
+++ b/Radiant/OnDemandExecutor.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "OnDemandExecutor.hpp"
 
 namespace Radiant

--- a/Radiant/OnDemandExecutor.hpp
+++ b/Radiant/OnDemandExecutor.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "Export.hpp"
 
 #include <folly/executors/SequencedExecutor.h>

--- a/Radiant/ProcessRunner.cpp
+++ b/Radiant/ProcessRunner.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "ProcessRunner.hpp"
 
 #ifndef RADIANT_MOBILE

--- a/Radiant/ProcessRunner.hpp
+++ b/Radiant/ProcessRunner.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RADIANT_PROCESSRUNNER_HPP
 #define RADIANT_PROCESSRUNNER_HPP
 

--- a/Radiant/ProcessRunnerPosix.cpp
+++ b/Radiant/ProcessRunnerPosix.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "ProcessRunner.hpp"
 #include "Trace.hpp"
 #include "Sleep.hpp"

--- a/Radiant/ProcessRunnerWin32.cpp
+++ b/Radiant/ProcessRunnerWin32.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "ProcessRunner.hpp"
 #include "Trace.hpp"
 

--- a/Radiant/QByteArrayHash.hpp
+++ b/Radiant/QByteArrayHash.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include <QtGlobal>

--- a/Radiant/QStringHash.hpp
+++ b/Radiant/QStringHash.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include <QtGlobal>

--- a/Radiant/ReentrantVector.hpp
+++ b/Radiant/ReentrantVector.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RADIANT_REENTRANTVECTOR_HPP
 #define RADIANT_REENTRANTVECTOR_HPP
 

--- a/Radiant/SecretStore.hpp
+++ b/Radiant/SecretStore.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "Export.hpp"

--- a/Radiant/SecretStoreDummy.cpp
+++ b/Radiant/SecretStoreDummy.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 /// This file contains a dummy implementation of SecretStore. It relies purely
 /// on file system security to protect the data, although there is an additional
 /// obfuscation layer to avoid storing anything in plain-text.

--- a/Radiant/SecretStoreLinux.cpp
+++ b/Radiant/SecretStoreLinux.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "SecretStore.hpp"
 #include "Trace.hpp"
 

--- a/Radiant/SecretStoreWin32.cpp
+++ b/Radiant/SecretStoreWin32.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "OnDemandExecutor.hpp"
 #include "SecretStore.hpp"
 #include "StringUtils.hpp"

--- a/Radiant/SerialPortHelpers.hpp
+++ b/Radiant/SerialPortHelpers.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef SERIALPORTHELPERS_HPP
 #define SERIALPORTHELPERS_HPP
 

--- a/Radiant/SetupSearchPaths.cpp
+++ b/Radiant/SetupSearchPaths.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "PlatformUtils.hpp"
 #include "Trace.hpp"
 #include "Radiant.hpp"

--- a/Radiant/SymbolRegistry.cpp
+++ b/Radiant/SymbolRegistry.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "SymbolRegistry.hpp"
 #include "Trace.hpp"
 

--- a/Radiant/SymbolRegistry.hpp
+++ b/Radiant/SymbolRegistry.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RADIANT_SYMBOLREGISTRY_HPP
 #define RADIANT_SYMBOLREGISTRY_HPP
 

--- a/Radiant/SynchronizedMultiQueue.cpp
+++ b/Radiant/SynchronizedMultiQueue.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "SynchronizedMultiQueue.hpp"
 
 #ifdef RADIANT_MSVC

--- a/Radiant/SynchronizedMultiQueue.hpp
+++ b/Radiant/SynchronizedMultiQueue.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RADIANT_SYNCHRONIZEDMULTIQUEUE_HPP
 #define RADIANT_SYNCHRONIZEDMULTIQUEUE_HPP
 

--- a/Radiant/SystemCpuTime.hpp
+++ b/Radiant/SystemCpuTime.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RADIANT_SYSTEM_CPU_TIME_HPP
 #define RADIANT_SYSTEM_CPU_TIME_HPP
 

--- a/Radiant/SystemCpuTimeLinux.cpp
+++ b/Radiant/SystemCpuTimeLinux.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "SystemCpuTime.hpp"
 #include "Trace.hpp"
 

--- a/Radiant/SystemCpuTimeOSX.cpp
+++ b/Radiant/SystemCpuTimeOSX.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "SystemCpuTime.hpp"
 
 namespace Radiant

--- a/Radiant/SystemCpuTimeWin32.cpp
+++ b/Radiant/SystemCpuTimeWin32.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "SystemCpuTime.hpp"
 #include "Trace.hpp"
 #include "StringUtils.hpp"

--- a/Radiant/TempFailureRetry.hpp
+++ b/Radiant/TempFailureRetry.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef TEMPFAILURERETRY_HPP
 #define TEMPFAILURERETRY_HPP
 

--- a/Radiant/TemporaryDir.cpp
+++ b/Radiant/TemporaryDir.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "TemporaryDir.hpp"
 
 #include <QCoreApplication>

--- a/Radiant/TemporaryDir.hpp
+++ b/Radiant/TemporaryDir.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RADIANT_TEMPORARY_DIR_HPP
 #define RADIANT_TEMPORARY_DIR_HPP
 

--- a/Radiant/ThreadChecks.cpp
+++ b/Radiant/ThreadChecks.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "ThreadChecks.hpp"
 
 namespace

--- a/Radiant/ThreadChecks.hpp
+++ b/Radiant/ThreadChecks.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RADIANT_THREADCHECKS_HPP
 #define RADIANT_THREADCHECKS_HPP
 

--- a/Radiant/ThreadPoolExecutor.cpp
+++ b/Radiant/ThreadPoolExecutor.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "ThreadPoolExecutor.hpp"
 #include "Mutex.hpp"
 

--- a/Radiant/ThreadPoolExecutor.hpp
+++ b/Radiant/ThreadPoolExecutor.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RADIANT_THREADPOOLEXECUTOR_HPP
 #define RADIANT_THREADPOOLEXECUTOR_HPP
 

--- a/Radiant/TimeTracker.hpp
+++ b/Radiant/TimeTracker.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "Timer.hpp"
 
 namespace Radiant

--- a/Radiant/TouchEvent.hpp
+++ b/Radiant/TouchEvent.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef TOUCHEVENT_HPP
 #define TOUCHEVENT_HPP
 

--- a/Radiant/TraceCrashHandlerFilter.cpp
+++ b/Radiant/TraceCrashHandlerFilter.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "TraceCrashHandlerFilter.hpp"
 #include "CrashHandler.hpp"
 #include "TimeStamp.hpp"

--- a/Radiant/TraceCrashHandlerFilter.hpp
+++ b/Radiant/TraceCrashHandlerFilter.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RADIANT_TRACE_CRASH_HANDLER_FILTER_HPP
 #define RADIANT_TRACE_CRASH_HANDLER_FILTER_HPP
 

--- a/Radiant/TraceDuplicateFilter.cpp
+++ b/Radiant/TraceDuplicateFilter.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "TraceDuplicateFilter.hpp"
 
 namespace Radiant

--- a/Radiant/TraceDuplicateFilter.hpp
+++ b/Radiant/TraceDuplicateFilter.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RADIANT_TRACE_DUPLICATE_FILTER_HPP
 #define RADIANT_TRACE_DUPLICATE_FILTER_HPP
 

--- a/Radiant/TraceQIODeviceFilter.cpp
+++ b/Radiant/TraceQIODeviceFilter.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "TraceQIODeviceFilter.hpp"
 
 #include <QIODevice>

--- a/Radiant/TraceQIODeviceFilter.hpp
+++ b/Radiant/TraceQIODeviceFilter.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RADIANT_TRACE_QIODEVICE_FILTER_HPP
 #define RADIANT_TRACE_QIODEVICE_FILTER_HPP
 

--- a/Radiant/TraceSeverityFilter.cpp
+++ b/Radiant/TraceSeverityFilter.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "TraceSeverityFilter.hpp"
 
 namespace Radiant

--- a/Radiant/TraceSeverityFilter.hpp
+++ b/Radiant/TraceSeverityFilter.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RADIANT_TRACE_SEVERITY_FILTER_HPP
 #define RADIANT_TRACE_SEVERITY_FILTER_HPP
 

--- a/Radiant/TraceStdFilter.cpp
+++ b/Radiant/TraceStdFilter.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "TraceStdFilter.hpp"
 
 #include "Thread.hpp"

--- a/Radiant/TraceStdFilter.hpp
+++ b/Radiant/TraceStdFilter.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RADIANT_TRACE_STD_FILTER_HPP
 #define RADIANT_TRACE_STD_FILTER_HPP
 

--- a/Radiant/TraceSyslogFilter.cpp
+++ b/Radiant/TraceSyslogFilter.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "TraceSyslogFilter.hpp"
 
 #include <syslog.h>

--- a/Radiant/TraceSyslogFilter.hpp
+++ b/Radiant/TraceSyslogFilter.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RADIANT_TRACE_SYSLOG_FILTER_HPP
 #define RADIANT_TRACE_SYSLOG_FILTER_HPP
 

--- a/Radiant/TraceWindowsDebugConsoleFilter.cpp
+++ b/Radiant/TraceWindowsDebugConsoleFilter.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "TraceWindowsDebugConsoleFilter.hpp"
 
 #include <Windows.h>

--- a/Radiant/TraceWindowsDebugConsoleFilter.hpp
+++ b/Radiant/TraceWindowsDebugConsoleFilter.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef TRACE_WINDOWS_DEBUG_CONSOLE_FILTER_HPP
 #define TRACE_WINDOWS_DEBUG_CONSOLE_FILTER_HPP
 

--- a/Radiant/VectorAllocator.hpp
+++ b/Radiant/VectorAllocator.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include <vector>

--- a/Radiant/Version.cpp
+++ b/Radiant/Version.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "Version.hpp"
 #include "Trace.hpp"
 

--- a/Radiant/Version.hpp
+++ b/Radiant/Version.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "Export.hpp"

--- a/Radiant/VersionString.cpp
+++ b/Radiant/VersionString.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "VersionString.hpp"
 
 #include <QRegExp>

--- a/Radiant/VersionString.hpp
+++ b/Radiant/VersionString.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "Export.hpp"

--- a/Radiant/generate-version.rb
+++ b/Radiant/generate-version.rb
@@ -1,3 +1,13 @@
+
+#
+# Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+# and others.
+#
+# This file is licensed under GNU Lesser General Public License (LGPL),
+# version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+# distributed with this source package or obtained from the GNU organization
+# (www.gnu.org).
+#
 require 'rbconfig'
 require 'fileutils'
 

--- a/Resonant/AudioLoopPortAudio.cpp
+++ b/Resonant/AudioLoopPortAudio.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "AudioLoopPortAudio.hpp"
 #include "Resonant.hpp"
 #include "DSPNetwork.hpp"

--- a/Resonant/AudioLoopPortAudio.hpp
+++ b/Resonant/AudioLoopPortAudio.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef AUDIOLOOPPORTAUDIO_HPP
 #define AUDIOLOOPPORTAUDIO_HPP
 

--- a/Resonant/AudioLoopPulseAudio.cpp
+++ b/Resonant/AudioLoopPulseAudio.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "AudioLoopPulseAudio.hpp"
 #include "DSPNetwork.hpp"
 #include "ModuleOutCollect.hpp"

--- a/Resonant/AudioLoopPulseAudio.hpp
+++ b/Resonant/AudioLoopPulseAudio.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RESONANT_AUDIOLOOPPULSEAUDIO_HPP
 #define RESONANT_AUDIOLOOPPULSEAUDIO_HPP
 

--- a/Resonant/LimiterAlgorithm.cpp
+++ b/Resonant/LimiterAlgorithm.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "LimiterAlgorithm.hpp"
 
 #include <Radiant/Trace.hpp>

--- a/Resonant/LimiterAlgorithm.hpp
+++ b/Resonant/LimiterAlgorithm.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RESONANT_LIMITERALGORITHM_HPP
 #define RESONANT_LIMITERALGORITHM_HPP
 

--- a/Resonant/ModuleBufferPlayer.cpp
+++ b/Resonant/ModuleBufferPlayer.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "ModuleBufferPlayer.hpp"
 
 static const int s_sampleRate = 44100;

--- a/Resonant/ModuleBufferPlayer.hpp
+++ b/Resonant/ModuleBufferPlayer.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RESONANT_MODULE_BUFFER_PLAYER_HPP
 #define RESONANT_MODULE_BUFFER_PLAYER_HPP
 

--- a/Resonant/PortAudioSource.cpp
+++ b/Resonant/PortAudioSource.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "PortAudioSource.hpp"
 
 #include <portaudio.h>

--- a/Resonant/PortAudioSource.hpp
+++ b/Resonant/PortAudioSource.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RESONANT_PORTAUDIOSOURCE_HPP
 #define RESONANT_PORTAUDIOSOURCE_HPP
 

--- a/Resonant/PulseAudioSource.cpp
+++ b/Resonant/PulseAudioSource.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "PulseAudioSource.hpp"
 #include "PulseAudioContext.hpp"
 #include "AudioLoopPulseAudio.hpp"

--- a/Resonant/PulseAudioSource.hpp
+++ b/Resonant/PulseAudioSource.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RESONANT_PULSEAUDIOSOURCE_HPP
 #define RESONANT_PULSEAUDIOSOURCE_HPP
 

--- a/Resonant/SourceInfo.hpp
+++ b/Resonant/SourceInfo.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RESONANT_SOURCEINFO_HPP
 #define RESONANT_SOURCEINFO_HPP
 

--- a/Valuable/AttributeAsset.cpp
+++ b/Valuable/AttributeAsset.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "AttributeAsset.hpp"
 #include "FileWatcher.hpp"
 

--- a/Valuable/AttributeAsset.hpp
+++ b/Valuable/AttributeAsset.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef VALUABLE_ATTRIBUTEASSET_HPP
 #define VALUABLE_ATTRIBUTEASSET_HPP
 

--- a/Valuable/AttributeEvent.cpp
+++ b/Valuable/AttributeEvent.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "AttributeEvent.hpp"
 
 #include <set>

--- a/Valuable/AttributeEvent.hpp
+++ b/Valuable/AttributeEvent.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "Export.hpp"

--- a/Valuable/AttributeSpline.cpp
+++ b/Valuable/AttributeSpline.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "AttributeSpline.hpp"
 
 #include <QTextStream>

--- a/Valuable/AttributeVectorContainer.hpp
+++ b/Valuable/AttributeVectorContainer.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef VALUABLE_ATTRIBUTEVECTORCONTAINER_HPP
 #define VALUABLE_ATTRIBUTEVECTORCONTAINER_HPP
 

--- a/Valuable/Event.hpp
+++ b/Valuable/Event.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "Export.hpp"

--- a/Valuable/EventImpl.hpp
+++ b/Valuable/EventImpl.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include <boost/container/small_vector.hpp>
 
 namespace Valuable

--- a/Valuable/EventWrapper.cpp
+++ b/Valuable/EventWrapper.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "EventWrapper.hpp"
 
 #include <Valuable/ListenerHolder.hpp>

--- a/Valuable/EventWrapper.hpp
+++ b/Valuable/EventWrapper.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef EVENTWRAPPER_HPP
 #define EVENTWRAPPER_HPP
 

--- a/Valuable/GraphicsCoordinates.cpp
+++ b/Valuable/GraphicsCoordinates.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "GraphicsCoordinates.hpp"
 
 namespace Valuable

--- a/Valuable/GraphicsCoordinates.hpp
+++ b/Valuable/GraphicsCoordinates.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef VALUABLE_GRAPHICS_COORDINATES_HPP
 #define VALUABLE_GRAPHICS_COORDINATES_HPP
 

--- a/Valuable/ListenerHolder.cpp
+++ b/Valuable/ListenerHolder.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "ListenerHolder.hpp"
 #include <utility>
 

--- a/Valuable/ListenerHolder.hpp
+++ b/Valuable/ListenerHolder.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef VALUABLE_LISTENERHOLDER_HPP
 #define VALUABLE_LISTENERHOLDER_HPP
 

--- a/Valuable/NodeListener.hpp
+++ b/Valuable/NodeListener.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "Node.hpp"

--- a/Valuable/NodeUtils.hpp
+++ b/Valuable/NodeUtils.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "Node.hpp"

--- a/Valuable/Reference.hpp
+++ b/Valuable/Reference.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include <memory>

--- a/Valuable/SimpleExpression.cpp
+++ b/Valuable/SimpleExpression.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "SimpleExpression.hpp"
 
 #include <Radiant/Trace.hpp>

--- a/Valuable/SimpleExpression.hpp
+++ b/Valuable/SimpleExpression.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef VALUABLE_SIMPLEEXPRESSION_HPP
 #define VALUABLE_SIMPLEEXPRESSION_HPP
 

--- a/Valuable/SimpleExpressionLink.cpp
+++ b/Valuable/SimpleExpressionLink.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "SimpleExpressionLink.hpp"
 
 namespace Valuable

--- a/Valuable/SimpleExpressionLink.hpp
+++ b/Valuable/SimpleExpressionLink.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef VALUABLE_SIMPLEEXPRESSIONLINK_HPP
 #define VALUABLE_SIMPLEEXPRESSIONLINK_HPP
 

--- a/Valuable/Symbol.cpp
+++ b/Valuable/Symbol.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "Symbol.hpp"
 
 namespace Valuable

--- a/Valuable/Symbol.hpp
+++ b/Valuable/Symbol.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "Export.hpp"

--- a/Valuable/SystemEvents.cpp
+++ b/Valuable/SystemEvents.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "SystemEvents.hpp"
 
 #ifdef RADIANT_WINDOWS

--- a/Valuable/SystemEvents.hpp
+++ b/Valuable/SystemEvents.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "Event.hpp"

--- a/Valuable/TransitionAnim.hpp
+++ b/Valuable/TransitionAnim.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef VALUABLE_TRANSITION_ANIM_HPP
 #define VALUABLE_TRANSITION_ANIM_HPP
 

--- a/Valuable/TransitionImpl.hpp
+++ b/Valuable/TransitionImpl.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef VALUABLE_TRANSITION_IMPL_HPP
 #define VALUABLE_TRANSITION_IMPL_HPP
 

--- a/Valuable/TransitionManager.cpp
+++ b/Valuable/TransitionManager.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "TransitionManager.hpp"
 #include "TransitionAnim.hpp"
 #include "TransitionImpl.hpp"

--- a/Valuable/TransitionManager.hpp
+++ b/Valuable/TransitionManager.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef VALUABLE_TRANSITION_MANAGER_HPP
 #define VALUABLE_TRANSITION_MANAGER_HPP
 

--- a/Valuable/WeakAttributePtr.hpp
+++ b/Valuable/WeakAttributePtr.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "Attribute.hpp"

--- a/Valuable/WeakNodePtr.hpp
+++ b/Valuable/WeakNodePtr.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "Node.hpp"

--- a/VideoDisplay/AVDecoder.hpp
+++ b/VideoDisplay/AVDecoder.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef VIDEODISPLAY_AVDECODER_HPP
 #define VIDEODISPLAY_AVDECODER_HPP
 

--- a/VideoDisplay/DummyDecoder.cpp
+++ b/VideoDisplay/DummyDecoder.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "DummyDecoder.hpp"
 
 #include <random>

--- a/VideoDisplay/DummyDecoder.hpp
+++ b/VideoDisplay/DummyDecoder.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef VIDEO_DISPLAY_DUMMY_DECODER_HPP
 #define VIDEO_DISPLAY_DUMMY_DECODER_HPP
 

--- a/VideoDisplay/FfmpegDecoder.cpp
+++ b/VideoDisplay/FfmpegDecoder.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 // For PRIx64
 #define __STDC_FORMAT_MACROS
 

--- a/VideoDisplay/FfmpegDecoder.hpp
+++ b/VideoDisplay/FfmpegDecoder.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef FFMPEGDECODER_HPP
 #define FFMPEGDECODER_HPP
 

--- a/VideoDisplay/FfmpegVideoFormatSelector.cpp
+++ b/VideoDisplay/FfmpegVideoFormatSelector.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "FfmpegVideoFormatSelector.hpp"
 
 namespace VideoDisplay

--- a/VideoDisplay/FfmpegVideoFormatSelector.hpp
+++ b/VideoDisplay/FfmpegVideoFormatSelector.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef VIDEO_DISPLAY_FFMPEG_VIDEO_FORMAT_SELECTOR_HPP
 #define VIDEO_DISPLAY_FFMPEG_VIDEO_FORMAT_SELECTOR_HPP
 

--- a/VideoDisplay/FfmpegVideoFormatSelectorLinux.cpp
+++ b/VideoDisplay/FfmpegVideoFormatSelectorLinux.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "FfmpegVideoFormatSelector.hpp"
 #include "FfmpegDecoder.hpp"
 

--- a/VideoDisplay/FfmpegVideoFormatSelectorWin.cpp
+++ b/VideoDisplay/FfmpegVideoFormatSelectorWin.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "FfmpegVideoFormatSelector.hpp"
 #include "FfmpegDecoder.hpp"
 

--- a/VideoDisplay/MWCapture.cpp
+++ b/VideoDisplay/MWCapture.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "MWCapture.hpp"
 
 #include <Radiant/Thread.hpp>

--- a/VideoDisplay/MWCapture.hpp
+++ b/VideoDisplay/MWCapture.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include <Radiant/Singleton.hpp>

--- a/VideoDisplay/RGBEasy.cpp
+++ b/VideoDisplay/RGBEasy.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "RGBEasy.hpp"
 
 #include <Radiant/Mutex.hpp>

--- a/VideoDisplay/RGBEasy.hpp
+++ b/VideoDisplay/RGBEasy.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef RGBEASY_HPP
 #define RGBEASY_HPP
 

--- a/VideoDisplay/Utils.hpp
+++ b/VideoDisplay/Utils.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef UTILS_HPP
 #define UTILS_HPP
 

--- a/VideoDisplay/V4L2Monitor.cpp
+++ b/VideoDisplay/V4L2Monitor.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "VideoCaptureMonitor.hpp"
 
 #include <Radiant/Trace.hpp>

--- a/VideoDisplay/VideoCaptureMonitor.hpp
+++ b/VideoDisplay/VideoCaptureMonitor.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #pragma once
 
 #include "Export.hpp"

--- a/VideoDisplay/WindowsVideoHelpers.cpp
+++ b/VideoDisplay/WindowsVideoHelpers.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "WindowsVideoHelpers.hpp"
 
 #include <tuple>

--- a/VideoDisplay/WindowsVideoHelpers.hpp
+++ b/VideoDisplay/WindowsVideoHelpers.hpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #ifndef WINDOWSSTRUCTURES_HPP
 #define WINDOWSSTRUCTURES_HPP
 

--- a/VideoDisplay/WindowsVideoMonitor.cpp
+++ b/VideoDisplay/WindowsVideoMonitor.cpp
@@ -1,3 +1,13 @@
+/* Copyright (C) 2007-2022: Multi Touch Oy, Helsinki University of Technology
+ * and others.
+ *
+ * This file is licensed under GNU Lesser General Public License (LGPL),
+ * version 2.1. The LGPL conditions can be found in file "LGPL.txt" that is
+ * distributed with this source package or obtained from the GNU organization
+ * (www.gnu.org).
+ *
+ */
+
 #include "VideoCaptureMonitor.hpp"
 
 #include <Shlwapi.h>


### PR DESCRIPTION
I added license headers to C++ source files that hadn't had them. I used the same (weird) format as Esa in 18150c63e42572fbc764b0371d9d2abb9f3f14e2 and changed only the year. I felt uncertain if I should refer to Multi Touch Oy or MultiTaction Oy, but all other license headers mention Multi Touch Oy and I decided to keep it consistent.